### PR TITLE
docs: overwritten functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+  - windows
+
+script: npx nyc -s npm run test -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - stage: check
+      script:
+        - npx aegir commitlint --travis
+        - npx aegir dep-check
+        - npm run lint
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ js-libp2p-pubsub
 
 ## Usage
 
-A pubsub implementation **MUST** override the `_processConnection`, `publish`, `subscribe` and `unsubscribe` functions. `add_peer` and `remove_peer` may be overwritten if the pubsub implementation needs to add custom logic when peers are added and remove. All the remaining functions **MUST NOT** be overwritten.
+A pubsub implementation **MUST** override the `_processConnection`, `publish`, `subscribe` and `unsubscribe` functions.
+
+Other functions, such as `_addPeer`, `_removePeer`, `_onDial`, `start` and `stop` may be overwritten if the pubsub implementation needs to add custom logic on them. It is important pointing out that `start` and `stop` must call `super`. The `start` function is responsible for mounting the pubsub protocol onto the libp2p node and sending its' subscriptions to every peer conneceted, while the `stop` function is responsible for unmounting the pubsub protocol and shutting down every connection
+
+All the remaining functions **MUST NOT** be overwritten.
 
 The following example aims to show how to create your pubsub implementation extending this base protocol. The pubsub implementation will handle the subscriptions logic.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ js-libp2p-pubsub
 
 A pubsub implementation **MUST** override the `_processConnection`, `publish`, `subscribe` and `unsubscribe` functions.
 
-Other functions, such as `_addPeer`, `_removePeer`, `_onDial`, `start` and `stop` may be overwritten if the pubsub implementation needs to add custom logic on them. It is important pointing out that `start` and `stop` must call `super`. The `start` function is responsible for mounting the pubsub protocol onto the libp2p node and sending its' subscriptions to every peer conneceted, while the `stop` function is responsible for unmounting the pubsub protocol and shutting down every connection
+Other functions, such as `_addPeer`, `_removePeer`, `_onDial`, `start` and `stop` may be overwritten if the pubsub implementation needs to add custom logic on them. It is important pointing out that `start` and `stop` **must** call `super`. The `start` function is responsible for mounting the pubsub protocol onto the libp2p node and sending its' subscriptions to every peer conneceted, while the `stop` function is responsible for unmounting the pubsub protocol and shutting down every connection
 
 All the remaining functions **MUST NOT** be overwritten.
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "err-code": "^1.1.2",
     "length-prefixed-stream": "^1.6.0",
     "protons": "^1.0.1",
+    "pull-length-prefixed": "^1.3.1",
     "pull-pushable": "^2.2.0",
+    "pull-stream": "^3.6.9",
     "time-cache": "~0.3.0"
   },
   "contributors": [


### PR DESCRIPTION
After the discussion in [libp2p/js-libp2p-floodsub#69](https://github.com/libp2p/js-libp2p-floodsub/pull/69), the docs were improved regarding the functions to overwrite.

The CI was also switched to travis in this PR