### PR TITLE
chore: export pubsub utils

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const errcode = require('err-code')
 
 const Peer = require('./peer')
 const message = require('./message')
+const utils = require('./utils')
 
 const nextTick = require('async/nextTick')
 
@@ -324,3 +325,4 @@ class PubsubBaseProtocol extends EventEmitter {
 
 module.exports = PubsubBaseProtocol
 module.exports.message = message
+module.exports.utils = utils


### PR DESCRIPTION
The utils codebase is useful both for `floodsub` and `gossipsub` implementations. 

[libp2p/js-libp2p-floodsub#76](https://github.com/libp2p/js-libp2p-floodsub/pull/76/files) browser CI is currently failing, as a result of requiring the file through its path.