### PR TITLE
feat: add support for message signing

### DIFF
--- a/src/message/index.js
+++ b/src/message/index.js
@@ -3,8 +3,12 @@
 const protons = require('protons')
 
 const rpcProto = protons(require('./rpc.proto.js'))
+const RPC = rpcProto.RPC
 const topicDescriptorProto = protons(require('./topic-descriptor.proto.js'))
 
 exports = module.exports
 exports.rpc = rpcProto
 exports.td = topicDescriptorProto
+exports.RPC = RPC
+exports.Message = RPC.Message
+exports.SubOpts = RPC.SubOpts

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -13,6 +13,8 @@ message RPC {
     optional bytes from = 1;
     optional bytes data = 2;
     optional bytes seqno = 3;
-    repeated string topicIDs = 4; 
+    repeated string topicIDs = 4;
+    optional bytes signature = 5;
+    optional bytes key = 6;
   }
 }`

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { Message } = require('./index')
+const SignPrefix = Buffer.from('libp2p-pubsub:')
+
+module.exports.SignPrefix = SignPrefix
+
+/**
+ * Signs the provided message with the given `peerId`
+ *
+ * @param {PeerId} peerId
+ * @param {Message} message
+ * @param {function(Error, Message)} callback
+ * @returns {void}
+ */
+module.exports.signMessage = function (peerId, message, callback) {
+  // Get the message in bytes, and prepend with the pubsub prefix
+  const bytes = Buffer.concat([
+    SignPrefix,
+    Message.encode(message)
+  ])
+
+  // Sign the bytes with the private key
+  peerId.privKey.sign(bytes, (err, signature) => {
+    if (err) return callback(err)
+
+    callback(null, {
+      ...message,
+      signature: signature,
+      key: peerId.pubKey.bytes
+    })
+  })
+}

--- a/src/peer.js
+++ b/src/peer.js
@@ -6,7 +6,7 @@ const pull = require('pull-stream')
 const setImmediate = require('async/setImmediate')
 const EventEmitter = require('events')
 
-const rpc = require('./message').rpc.RPC
+const { RPC } = require('./message')
 
 /**
  * The known state of a connected peer.
@@ -109,7 +109,7 @@ class Peer extends EventEmitter {
       })
     })
 
-    this.write(rpc.encode({
+    this.write(RPC.encode({
       subscriptions: subs
     }))
   }
@@ -139,7 +139,7 @@ class Peer extends EventEmitter {
    * @returns {undefined}
    */
   sendMessages (msgs) {
-    this.write(rpc.encode({
+    this.write(RPC.encode({
       msgs: msgs
     }))
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,15 +81,17 @@ exports.normalizeInRpcMessages = (messages) => {
   })
 }
 
+exports.normalizeOutRpcMessage = (message) => {
+  const m = Object.assign({}, message)
+  if (typeof message.from === 'string' || message.from instanceof String) {
+    m.from = bs58.decode(message.from)
+  }
+  return m
+}
+
 exports.normalizeOutRpcMessages = (messages) => {
   if (!messages) {
     return messages
   }
-  return messages.map((msg) => {
-    const m = Object.assign({}, msg)
-    if (typeof msg.from === 'string' || msg.from instanceof String) {
-      m.from = bs58.decode(msg.from)
-    }
-    return m
-  })
+  return messages.map(exports.normalizeOutRpcMessage)
 }

--- a/test/sign.spec.js
+++ b/test/sign.spec.js
@@ -1,0 +1,53 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 5] */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+
+const { Message } = require('../src/message')
+const { signMessage, SignPrefix } = require('../src/message/sign')
+const PeerId = require('peer-id')
+const { randomSeqno } = require('../src/utils')
+
+describe('message signing', () => {
+  let peerId
+  before((done) => {
+    peerId = PeerId.create({
+      bits: 1024
+    }, (err, id) => {
+      peerId = id
+      done(err)
+    })
+  })
+
+  it('should be able to sign a message', (done) => {
+    const message = {
+      from: 'QmABC',
+      data: 'hello',
+      seqno: randomSeqno(),
+      topicIDs: ['test-topic']
+    }
+
+    const bytesToSign = Buffer.concat([SignPrefix, Message.encode(message)])
+
+    peerId.privKey.sign(bytesToSign, (err, expectedSignature) => {
+      if (err) return done(err)
+
+      signMessage(peerId, message, (err, signedMessage) => {
+        if (err) return done(err)
+
+        // Check the signature and public key
+        expect(signedMessage.signature).to.eql(expectedSignature)
+        expect(signedMessage.key).to.eql(peerId.pubKey.bytes)
+
+        // Verify the signature
+        peerId.pubKey.verify(bytesToSign, signedMessage.signature, (err, verified) => {
+          expect(verified).to.eql(true)
+          done(err)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
BREAKING CHANGE: as .publish should now sign messages (via _buildMessage) it now requires a callback since signing is async. This also adds an options param to the pubsub constructor to allow for disabling signing. While this change shouldnt break things upstream, implementations need to be sure to call _buildMessage for each message they will publish.

Adds signing support (on by default) for https://github.com/libp2p/js-libp2p-pubsub/issues/16.

