### PR TITLE
feat: verify signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ class PubsubImplementation extends Pubsub {
 }
 ```
 
+### Validate
+
+Validates the signature of a message.
+
+#### `pubsub.validate(message, callback)`
+
+##### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| message | `Message` | a pubsub message |
+| callback | `function(Error, Boolean)` | calls back with true if the message is valid |
+
 ## Implementations using this base protocol
 
 You can use the following implementations as examples for building your own pubsub implementation.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "pull-length-prefixed": "^1.3.1",
     "pull-pushable": "^2.2.0",
     "pull-stream": "^3.6.9",
+    "sinon": "^7.3.2",
     "time-cache": "~0.3.0"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -359,6 +359,7 @@ class PubsubBaseProtocol extends EventEmitter {
    * Validates the given message. The signature will be checked for authenticity.
    * @param {rpc.RPC.Message} message
    * @param {function(Error, Boolean)} callback
+   * @returns {void}
    */
   validate (message, callback) {
     // If strict signing is on and we have no signature, abort

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,12 @@ class PubsubBaseProtocol extends EventEmitter {
     }
 
     /**
+     * If message signing should be required for incoming messages
+     * @type {boolean}
+     */
+    this.strictSigning = options.strictSigning
+
+    /**
      * Map of topics to which peers are subscribed to
      *
      * @type {Map<string, Peer>}
@@ -374,6 +380,9 @@ class PubsubBaseProtocol extends EventEmitter {
         if (err) return callback(err)
         callback(null, valid)
       })
+    } else {
+      // The message is valid
+      nextTick(callback, null, true)
     }
   }
 }

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -1,9 +1,8 @@
 'use strict'
 
+const PeerId = require('peer-id')
 const { Message } = require('./index')
 const SignPrefix = Buffer.from('libp2p-pubsub:')
-
-module.exports.SignPrefix = SignPrefix
 
 /**
  * Signs the provided message with the given `peerId`
@@ -13,7 +12,7 @@ module.exports.SignPrefix = SignPrefix
  * @param {function(Error, Message)} callback
  * @returns {void}
  */
-module.exports.signMessage = function (peerId, message, callback) {
+function signMessage (peerId, message, callback) {
   // Get the message in bytes, and prepend with the pubsub prefix
   const bytes = Buffer.concat([
     SignPrefix,
@@ -30,4 +29,58 @@ module.exports.signMessage = function (peerId, message, callback) {
       key: peerId.pubKey.bytes
     })
   })
+}
+
+/**
+ * Verifies the signature of the given message
+ * @param {rpc.RPC.Message} message
+ * @param {function(Error, Boolean)} callback
+ */
+function verifySignature (message, callback) {
+  // Get message sans the signature
+  let baseMessage = { ...message }
+  delete baseMessage.signature
+  delete baseMessage.key
+  const bytes = Buffer.concat([
+    SignPrefix,
+    Message.encode(baseMessage)
+  ])
+
+  // Get the public key
+  messagePublicKey(message, (err, pubKey) => {
+    if (err) return callback(err, false)
+    // Verify the base message
+    pubKey.verify(bytes, message.signature, callback)
+  })
+}
+
+/**
+ * Returns the PublicKey associated with the given message.
+ * If no, valid PublicKey can be retrieved an error will be returned.
+ *
+ * @param {Message} message
+ * @param {function(Error, PublicKey)} callback
+ * @returns {void}
+ */
+function messagePublicKey (message, callback) {
+  if (message.key) {
+    PeerId.createFromPubKey(message.key, (err, peerId) => {
+      if (err) return callback(err, null)
+      // the key belongs to the sender, return the key
+      if (peerId.isEqual(message.from)) return callback(null, peerId.pubKey)
+      // We couldn't validate pubkey is from the originator, error
+      callback(new Error('Public Key does not match the originator'))
+    })
+    return
+  }
+  // TODO: Once js libp2p supports inlining public keys with the peer id
+  // attempt to unmarshal the public key here.
+  callback(new Error('Could not get the public key from the originator id'))
+}
+
+module.exports = {
+  messagePublicKey,
+  signMessage,
+  SignPrefix,
+  verifySignature
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,17 +68,30 @@ exports.ensureArray = (maybeArray) => {
   return maybeArray
 }
 
+/**
+ * Ensures `message.from` is base58 encoded
+ * @param {Object} message
+ * @param {Buffer|String} message.from
+ * @return {Object}
+ */
+exports.normalizeInRpcMessage = (message) => {
+  const m = Object.assign({}, message)
+  if (Buffer.isBuffer(message.from)) {
+    m.from = bs58.encode(message.from)
+  }
+  return m
+}
+
+/**
+ * The same as `normalizeInRpcMessage`, but performed on an array of messages
+ * @param {Object[]} messages
+ * @return {Object[]}
+ */
 exports.normalizeInRpcMessages = (messages) => {
   if (!messages) {
     return messages
   }
-  return messages.map((msg) => {
-    const m = Object.assign({}, msg)
-    if (Buffer.isBuffer(msg.from)) {
-      m.from = bs58.encode(msg.from)
-    }
-    return m
-  })
+  return messages.map(exports.normalizeInRpcMessage)
 }
 
 exports.normalizeOutRpcMessage = (message) => {

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -8,10 +8,8 @@ const expect = chai.expect
 const series = require('async/series')
 const parallel = require('async/parallel')
 
-const { Message } = require('../src/message')
-const { SignPrefix } = require('../src/message/sign')
 const PubsubBaseProtocol = require('../src')
-const { randomSeqno, normalizeOutRpcMessage } = require('../src/utils')
+const { randomSeqno } = require('../src/utils')
 const utils = require('./utils')
 const createNode = utils.createNode
 

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -103,11 +103,6 @@ describe('pubsub base protocol', () => {
       psA._buildMessage(message, (err, signedMessage) => {
         expect(err).to.not.exist()
 
-        // const bytesToSign = Buffer.concat([
-        //   SignPrefix,
-        //   Message.encode(normalizeOutRpcMessage(message))
-        // ])
-
         psA.validate(signedMessage, (err, verified) => {
           expect(verified).to.eql(true)
           done(err)

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -96,7 +96,7 @@ describe('pubsub base protocol', () => {
 
     it('_buildMessage normalizes and signs messages', (done) => {
       const message = {
-        from: 'QmABC',
+        from: psA.peerId.id,
         data: 'hello',
         seqno: randomSeqno(),
         topicIDs: ['test-topic']
@@ -105,12 +105,12 @@ describe('pubsub base protocol', () => {
       psA._buildMessage(message, (err, signedMessage) => {
         expect(err).to.not.exist()
 
-        const bytesToSign = Buffer.concat([
-          SignPrefix,
-          Message.encode(normalizeOutRpcMessage(message))
-        ])
+        // const bytesToSign = Buffer.concat([
+        //   SignPrefix,
+        //   Message.encode(normalizeOutRpcMessage(message))
+        // ])
 
-        psA.peerId.pubKey.verify(bytesToSign, signedMessage.signature, (err, verified) => {
+        psA.validate(signedMessage, (err, verified) => {
           expect(verified).to.eql(true)
           done(err)
         })


### PR DESCRIPTION
This adds an option to pubsub, `strictSigning` which defaults to `true`. When `validate` is called, the signature of the message will be verified, unless `strictSigning` is disabled.

I originally intended to enforce this at the pubsub interface layer so that both Floodsub and Gossipsub could get the behavior out of the box, however, the implementations don't use the same message processing pipeline. Ideally, we should unify this more so that the abstraction layer can do common validation, like signature validation, before moving on to implementation specific message processing.

As it stands, `validate` is going to need to be called in both implementations in their respective pipelines. I will be creating PRs for both implementations.