### PR TITLE
allow inline public keys in messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "libp2p-websocket-star-rendezvous": "~0.3.0",
     "lodash": "^4.17.11",
     "multiaddr": "^6.0.6",
-    "peer-id": "~0.12.2",
+    "peer-id": "~0.12.5",
     "peer-info": "~0.15.1"
   },
   "dependencies": {

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -72,9 +72,14 @@ function messagePublicKey (message, callback) {
       callback(new Error('Public Key does not match the originator'))
     })
     return
+  } else {
+    // should be available in the from property of the message (peer id)
+    const from = PeerId.createFromBytes(message.from)
+    if (from.pubKey) {
+      return callback(null, from.pubKey)
+    }
   }
-  // TODO: Once js libp2p supports inlining public keys with the peer id
-  // attempt to unmarshal the public key here.
+
   callback(new Error('Could not get the public key from the originator id'))
 }
 

--- a/test/sign.spec.js
+++ b/test/sign.spec.js
@@ -56,6 +56,42 @@ describe('message signing', () => {
     })
   })
 
+  it('should be able to extract the public key from an inlined key', (done) => {
+    const testSecp256k1 = (peerId) => {
+      const message = {
+        from: peerId.id,
+        data: 'hello',
+        seqno: randomSeqno(),
+        topicIDs: ['test-topic']
+      }
+
+      const bytesToSign = Buffer.concat([SignPrefix, Message.encode(message)])
+      peerId.privKey.sign(bytesToSign, (err, expectedSignature) => {
+        if (err) return done(err)
+
+        signMessage(peerId, message, (err, signedMessage) => {
+          if (err) return done(err)
+
+          // Check the signature and public key
+          expect(signedMessage.signature).to.eql(expectedSignature)
+          signedMessage.key = undefined
+
+          // Verify the signature
+          verifySignature(signedMessage, (err, verified) => {
+            expect(err).to.not.exist()
+            expect(verified).to.eql(true)
+            done(err)
+          })
+        })
+      })
+    }
+
+    PeerId.create({ keyType: 'secp256k1', bits: 256 }, (err, peerId) => {
+      expect(err).to.not.exist()
+      testSecp256k1(peerId)
+    })
+  })
+
   it('should be able to extract the public key from the message', (done) => {
     const message = {
       from: peerId.id,


### PR DESCRIPTION
This has unlocked the ability for supporting pubsub messages with Secp256k1 keys: https://github.com/libp2p/js-peer-id/pull/102

This is a pretty straight forward PR, if the message.key does not exist, it attempts to get the public key from the message from and if that doesn't exist, errors as it did previously.