### PR TITLE
chore: remove peer-info usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ TODO: add explanation for registrar!
 const Pubsub = require('libp2p-pubsub')
 
 class PubsubImplementation extends Pubsub {
-  constructor({ peerInfo, registrar, ...options })
+  constructor({ peerId, registrar, ...options })
     super({
       debugName: 'libp2p:pubsub',
       multicodecs: '/pubsub-implementation/1.0.0',
-      peerInfo: peerInfo,
+      peerId: peerId,
       registrar: registrar,
       signMessages: options.signMessages,
       strictSigning: options.strictSigning

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "it-pipe": "^1.0.1",
     "it-pushable": "^1.3.2",
     "libp2p-crypto": "~0.17.0",
-    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x",
+    "libp2p-interfaces": "^0.3.0",
     "peer-id": "~0.13.3",
     "protons": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
     "multiaddr": "^7.2.1",
-    "peer-id": "~0.13.3",
-    "peer-info": "~0.17.0",
     "sinon": "^9.0.0"
   },
   "dependencies": {
@@ -61,7 +59,8 @@
     "it-pipe": "^1.0.1",
     "it-pushable": "^1.3.2",
     "libp2p-crypto": "~0.17.0",
-    "libp2p-interfaces": "^0.2.3",
+    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x",
+    "peer-id": "~0.13.3",
     "protons": "^1.0.1"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,6 @@ class PubsubBaseProtocol extends EventEmitter {
     this.log.err = debug(`${debugName}:error`)
 
     this.multicodecs = utils.ensureArray(multicodecs)
-    this.signMessages = peerId
     this.registrar = registrar
 
     this.started = false
@@ -174,7 +173,10 @@ class PubsubBaseProtocol extends EventEmitter {
     const peerId = connection.remotePeer
     const idB58Str = peerId.toB58String()
 
-    const peer = this._addPeer(new Peer(peerId, [protocol]))
+    const peer = this._addPeer(new Peer({
+      id: peerId,
+      protocols: [protocol]
+    }))
 
     peer.attachConnection(stream)
     this._processMessages(idB58Str, stream, peer)
@@ -190,7 +192,11 @@ class PubsubBaseProtocol extends EventEmitter {
     const idB58Str = peerId.toB58String()
     this.log('connected', idB58Str)
 
-    const peer = this._addPeer(new Peer(peerId, this.multicodecs))
+    const peer = this._addPeer(new Peer({
+      id: peerId,
+      protocols: this.multicodecs
+    }))
+
     try {
       const { stream } = await conn.newStream(this.multicodecs)
       peer.attachConnection(stream)

--- a/src/peer.js
+++ b/src/peer.js
@@ -16,7 +16,7 @@ class Peer extends EventEmitter {
    * @param {PeerId} id
    * @param {Array<string>} protocols
    */
-  constructor (id, protocols) {
+  constructor ({ id, protocols }) {
     super()
 
     /**

--- a/src/peer.js
+++ b/src/peer.js
@@ -13,15 +13,20 @@ const { RPC } = require('./message')
  */
 class Peer extends EventEmitter {
   /**
-   * @param {PeerInfo} info
+   * @param {PeerId} id
+   * @param {Array<string>} protocols
    */
-  constructor (info) {
+  constructor (id, protocols) {
     super()
 
     /**
-     * @type {PeerInfo}
+     * @type {PeerId}
      */
-    this.info = info
+    this.id = id
+    /**
+     * @type {string}
+     */
+    this.protocols = protocols
     /**
      * @type {Connection}
      */
@@ -65,7 +70,7 @@ class Peer extends EventEmitter {
    */
   write (msg) {
     if (!this.isWritable) {
-      const id = this.info.id.toB58String()
+      const id = this.id.toB58String()
       throw new Error('No writable connection to ' + id)
     }
 

--- a/test/instance.spec.js
+++ b/test/instance.spec.js
@@ -7,13 +7,13 @@ chai.use(require('chai-spies'))
 const expect = chai.expect
 
 const PubsubBaseProtocol = require('../src')
-const { createPeerInfo, mockRegistrar } = require('./utils')
+const { createPeerId, mockRegistrar } = require('./utils')
 
 describe('should validate instance parameters', () => {
-  let peerInfo
+  let peerId
 
   before(async () => {
-    peerInfo = await createPeerInfo()
+    peerId = await createPeerId()
   })
 
   it('should throw if no debugName is provided', () => {
@@ -30,7 +30,7 @@ describe('should validate instance parameters', () => {
     }).to.throw()
   })
 
-  it('should throw if no peerInfo is provided', () => {
+  it('should throw if no peerId is provided', () => {
     expect(() => {
       new PubsubBaseProtocol({ // eslint-disable-line no-new
         debugName: 'pubsub',
@@ -39,12 +39,12 @@ describe('should validate instance parameters', () => {
     }).to.throw()
   })
 
-  it('should throw if an invalid peerInfo is provided', () => {
+  it('should throw if an invalid peerId is provided', () => {
     expect(() => {
       new PubsubBaseProtocol({ // eslint-disable-line no-new
         debugName: 'pubsub',
         multicodecs: '/pubsub/1.0.0',
-        peerInfo: 'fake-peer-info'
+        peerId: 'fake-peer-id'
       })
     }).to.throw()
   })
@@ -54,7 +54,7 @@ describe('should validate instance parameters', () => {
       new PubsubBaseProtocol({ // eslint-disable-line no-new
         debugName: 'pubsub',
         multicodecs: '/pubsub/1.0.0',
-        peerInfo: peerInfo
+        peerId: peerId
       })
     }).to.throw()
   })
@@ -64,7 +64,7 @@ describe('should validate instance parameters', () => {
       new PubsubBaseProtocol({ // eslint-disable-line no-new
         debugName: 'pubsub',
         multicodecs: '/pubsub/1.0.0',
-        peerInfo: peerInfo,
+        peerId: peerId,
         registrar: mockRegistrar
       })
     }).not.to.throw()

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -11,7 +11,7 @@ const PubsubBaseProtocol = require('../src')
 const Peer = require('../src/peer')
 const { randomSeqno } = require('../src/utils')
 const {
-  createPeerInfo,
+  createPeerId,
   createMockRegistrar,
   mockRegistrar,
   PubsubImplementation,
@@ -24,7 +24,7 @@ describe('pubsub base protocol', () => {
     let sinonMockRegistrar
 
     beforeEach(async () => {
-      const peerInfo = await createPeerInfo()
+      const peerId = await createPeerId()
       sinonMockRegistrar = {
         handle: sinon.stub(),
         register: sinon.stub(),
@@ -34,7 +34,7 @@ describe('pubsub base protocol', () => {
       pubsub = new PubsubBaseProtocol({
         debugName: 'pubsub',
         multicodecs: '/pubsub/1.0.0',
-        peerInfo: peerInfo,
+        peerId: peerId,
         registrar: sinonMockRegistrar
       })
 
@@ -72,15 +72,15 @@ describe('pubsub base protocol', () => {
   })
 
   describe('should handle message creation and signing', () => {
-    let peerInfo
+    let peerId
     let pubsub
 
     before(async () => {
-      peerInfo = await createPeerInfo()
+      peerId = await createPeerId()
       pubsub = new PubsubBaseProtocol({
         debugName: 'pubsub',
         multicodecs: '/pubsub/1.0.0',
-        peerInfo: peerInfo,
+        peerId: peerId,
         registrar: mockRegistrar
       })
     })
@@ -91,7 +91,7 @@ describe('pubsub base protocol', () => {
 
     it('_buildMessage normalizes and signs messages', async () => {
       const message = {
-        from: peerInfo.id.id,
+        from: peerId.id,
         data: 'hello',
         seqno: randomSeqno(),
         topicIDs: ['test-topic']
@@ -105,7 +105,7 @@ describe('pubsub base protocol', () => {
 
     it('validate with strict signing off will validate a present signature', async () => {
       const message = {
-        from: peerInfo.id.id,
+        from: peerId.id,
         data: 'hello',
         seqno: randomSeqno(),
         topicIDs: ['test-topic']
@@ -121,7 +121,7 @@ describe('pubsub base protocol', () => {
 
     it('validate with strict signing requires a signature', async () => {
       const message = {
-        from: peerInfo.id.id,
+        from: peerId.id,
         data: 'hello',
         seqno: randomSeqno(),
         topicIDs: ['test-topic']
@@ -136,17 +136,17 @@ describe('pubsub base protocol', () => {
   describe('should be able to register two nodes', () => {
     const protocol = '/pubsub/1.0.0'
     let pubsubA, pubsubB
-    let peerInfoA, peerInfoB
+    let peerIdA, peerIdB
     const registrarRecordA = {}
     const registrarRecordB = {}
 
     // mount pubsub
     beforeEach(async () => {
-      peerInfoA = await createPeerInfo()
-      peerInfoB = await createPeerInfo()
+      peerIdA = await createPeerId()
+      peerIdB = await createPeerId()
 
-      pubsubA = new PubsubImplementation(protocol, peerInfoA, createMockRegistrar(registrarRecordA))
-      pubsubB = new PubsubImplementation(protocol, peerInfoB, createMockRegistrar(registrarRecordB))
+      pubsubA = new PubsubImplementation(protocol, peerIdA, createMockRegistrar(registrarRecordA))
+      pubsubB = new PubsubImplementation(protocol, peerIdB, createMockRegistrar(registrarRecordB))
     })
 
     // start pubsub
@@ -176,12 +176,12 @@ describe('pubsub base protocol', () => {
       // Notice peers of connection
       const [c0, c1] = ConnectionPair()
 
-      await onConnectA(peerInfoB, c0)
+      await onConnectA(peerIdB, c0)
       await handlerB({
         protocol,
         stream: c1.stream,
         connection: {
-          remotePeer: peerInfoA.id
+          remotePeer: peerIdA
         }
       })
 
@@ -198,12 +198,12 @@ describe('pubsub base protocol', () => {
       const error = new Error('new stream error')
       sinon.stub(c0, 'newStream').throws(error)
 
-      await onConnectA(peerInfoB, c0)
+      await onConnectA(peerIdB, c0)
       await handlerB({
         protocol,
         stream: c1.stream,
         connection: {
-          remotePeer: peerInfoA.id
+          remotePeer: peerIdA
         }
       })
 
@@ -219,18 +219,18 @@ describe('pubsub base protocol', () => {
       // Notice peers of connection
       const [c0, c1] = ConnectionPair()
 
-      await onConnectA(peerInfoB, c0)
+      await onConnectA(peerIdB, c0)
       await handlerB({
         protocol,
         stream: c1.stream,
         connection: {
-          remotePeer: peerInfoA.id
+          remotePeer: peerIdA
         }
       })
 
       // Notice peers of disconnect
-      onDisconnectA(peerInfoB)
-      onDisconnectB(peerInfoA)
+      onDisconnectA(peerIdB)
+      onDisconnectB(peerIdA)
 
       expect(pubsubA.peers.size).to.be.eql(0)
       expect(pubsubB.peers.size).to.be.eql(0)
@@ -242,22 +242,22 @@ describe('pubsub base protocol', () => {
       expect(pubsubA.peers.size).to.be.eql(0)
 
       // Notice peers of disconnect
-      onDisconnectA(peerInfoB)
+      onDisconnectA(peerIdB)
 
       expect(pubsubA.peers.size).to.be.eql(0)
     })
   })
 
   describe('getSubscribers', () => {
-    let peerInfo
+    let peerId
     let pubsub
 
     beforeEach(async () => {
-      peerInfo = await createPeerInfo()
+      peerId = await createPeerId()
       pubsub = new PubsubBaseProtocol({
         debugName: 'pubsub',
         multicodecs: '/pubsub/1.0.0',
-        peerInfo: peerInfo,
+        peerId: peerId,
         registrar: mockRegistrar
       })
     })
@@ -301,8 +301,8 @@ describe('pubsub base protocol', () => {
       expect(peersSubscribed).to.be.empty()
 
       // Set mock peer subscribed
-      const peer = new Peer(peerInfo)
-      const id = peer.info.id.toB58String()
+      const peer = new Peer(peerId)
+      const id = peer.id.toB58String()
 
       peer.topics.add(topic)
       pubsub.peers.set(id, peer)

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -301,7 +301,7 @@ describe('pubsub base protocol', () => {
       expect(peersSubscribed).to.be.empty()
 
       // Set mock peer subscribed
-      const peer = new Peer(peerId)
+      const peer = new Peer({ id: peerId })
       const id = peer.id.toB58String()
 
       peer.topics.add(topic)

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -5,23 +5,22 @@ const pipe = require('it-pipe')
 const DuplexPair = require('it-pair/duplex')
 
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 
 const PubsubBaseProtocol = require('../../src')
 const { message } = require('../../src')
 
-exports.createPeerInfo = async () => {
+exports.createPeerId = async () => {
   const peerId = await PeerId.create({ bits: 1024 })
 
-  return PeerInfo.create(peerId)
+  return peerId
 }
 
 class PubsubImplementation extends PubsubBaseProtocol {
-  constructor (protocol, peerInfo, registrar) {
+  constructor (protocol, peerId, registrar) {
     super({
       debugName: 'libp2p:pubsub',
       multicodecs: protocol,
-      peerInfo: peerInfo,
+      peerId: peerId,
       registrar: registrar
     })
   }


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR removes the `peer-info` usage on pubsub internal peer data structure. Moreover, this uses the new topology API, which also uses `peer-id` instead of `peer-info`

This changes have impact on pubsub implementations.

BREAKING CHANGE: pubsub internal peer does not have info propery anymore and use the new topology api with peer-id instead of peer-info

Needs:

- [x]  [libp2p/js-libp2p-interfaces#42](https://github.com/libp2p/js-libp2p-interfaces/pull/42)