### PR TITLE
fix: use unidirectional streams

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,6 @@ class PubsubBaseProtocol extends EventEmitter {
       protocols: [protocol]
     }))
 
-    peer.attachConnection(stream)
     this._processMessages(idB58Str, stream, peer)
   }
 
@@ -200,7 +199,6 @@ class PubsubBaseProtocol extends EventEmitter {
     try {
       const { stream } = await conn.newStream(this.multicodecs)
       peer.attachConnection(stream)
-      this._processMessages(idB58Str, stream, peer)
     } catch (err) {
       this.log.err(err)
     }

--- a/src/peer.js
+++ b/src/peer.js
@@ -87,6 +87,8 @@ class Peer extends EventEmitter {
     this.conn = conn
     this.stream = pushable({
       onEnd: () => {
+        // close readable side of the stream
+        this.conn.reset && this.conn.reset()
         this.conn = null
         this.stream = null
         this.emit('close')


### PR DESCRIPTION
This PR makes libp2p pubsub subsystem use unidirectional streams instead of bidirectional streams per discussion on [ipfs/go-ipfs#7390](https://github.com/ipfs/go-ipfs/issues/7390).

More details about the reasoning for this can be found in https://discuss.libp2p.io/t/gossip-questions/257/6