### PR TITLE
chore: refactor message normalization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,16 @@ const {
   verifySignature
 } = require('./message/sign')
 
+/**
+ * @typedef {Object} InMessage
+ * @property {string} from
+ * @property {string} receivedFrom
+ * @property {string[]} topicIDs
+ * @property {Buffer} data
+ * @property {Buffer} [signature]
+ * @property {Buffer} [key]
+ */
+
 function validateRegistrar (registrar) {
   // registrar handling
   if (typeof registrar !== 'object') {
@@ -257,7 +267,7 @@ class PubsubBaseProtocol extends EventEmitter {
 
   /**
    * Validates the given message. The signature will be checked for authenticity.
-   * @param {rpc.RPC.Message} message
+   * @param {InMessage} message
    * @returns {Promise<Boolean>}
    */
   async validate (message) { // eslint-disable-line require-await

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -53,7 +53,7 @@ async function verifySignature (message) {
  * Returns the PublicKey associated with the given message.
  * If no, valid PublicKey can be retrieved an error will be returned.
  *
- * @param {Message} message
+ * @param {InMessage} message
  * @returns {Promise<PublicKey>}
  */
 async function messagePublicKey (message) {
@@ -66,7 +66,12 @@ async function messagePublicKey (message) {
     throw new Error('Public Key does not match the originator')
   } else {
     // should be available in the from property of the message (peer id)
-    const from = PeerId.createFromBytes(message.from)
+    let from
+    if (typeof message.from === 'string') {
+      from = PeerId.createFromB58String(message.from)
+    } else {
+      from = PeerId.createFromBytes(message.from)
+    }
 
     if (from.pubKey) {
       return from.pubKey

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,26 +73,18 @@ exports.ensureArray = (maybeArray) => {
  * Ensures `message.from` is base58 encoded
  * @param {Object} message
  * @param {Buffer|String} message.from
+ * @param {PeerId} peerId
  * @return {Object}
  */
-exports.normalizeInRpcMessage = (message) => {
+exports.normalizeInRpcMessage = (message, peerId) => {
   const m = Object.assign({}, message)
   if (Buffer.isBuffer(message.from)) {
     m.from = multibase.encode('base58btc', message.from).toString().slice(1)
   }
-  return m
-}
-
-/**
- * The same as `normalizeInRpcMessage`, but performed on an array of messages
- * @param {Object[]} messages
- * @return {Object[]}
- */
-exports.normalizeInRpcMessages = (messages) => {
-  if (!messages) {
-    return messages
+  if (peerId) {
+    m.receivedFrom = peerId.toB58String()
   }
-  return messages.map(exports.normalizeInRpcMessage)
+  return m
 }
 
 exports.normalizeOutRpcMessage = (message) => {
@@ -101,11 +93,4 @@ exports.normalizeOutRpcMessage = (message) => {
     m.from = multibase.decode('z' + message.from)
   }
   return m
-}
-
-exports.normalizeOutRpcMessages = (messages) => {
-  if (!messages) {
-    return messages
-  }
-  return messages.map(exports.normalizeOutRpcMessage)
 }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -59,7 +59,9 @@ describe('utils', () => {
       { from: stringId },
       { from: stringId }
     ]
-    expect(utils.normalizeInRpcMessages(m)).to.deep.eql(expected)
+    for (let i = 0; i < m.length; i++) {
+      expect(utils.normalizeInRpcMessage(m[i])).to.deep.eql(expected[i])
+    }
   })
 
   it('converts an OUT msg.from to binary', () => {
@@ -73,6 +75,8 @@ describe('utils', () => {
       { from: binaryId },
       { from: binaryId }
     ]
-    expect(utils.normalizeOutRpcMessages(m)).to.deep.eql(expected)
+    for (let i = 0; i < m.length; i++) {
+      expect(utils.normalizeOutRpcMessage(m[i])).to.deep.eql(expected[i])
+    }
   })
 })


### PR DESCRIPTION
Addresses https://github.com/libp2p/js-libp2p-pubsub/issues/50

Additionally includes a `receivedFrom` entry on a normalized InMessage. This will aid downstream routers by creating a fully self-contained object that doesn't need to have the receivedFrom peerId passed as a separate parameter. This idea was taken from go-libp2p-pubsub.

This PR is backwards compatible, future PRs will likely break compatibility at some point.