### PR TITLE
feat: update publish function signature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ class PubsubBaseProtocol extends EventEmitter {
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
    * @abstract
    * @param {Array<string>|string} topics
-   * @param {Buffer | string} message
+   * @param {Buffer} message
    * @returns {Promise<void>}
    *
    */

--- a/src/index.js
+++ b/src/index.js
@@ -314,8 +314,8 @@ class PubsubBaseProtocol extends EventEmitter {
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
    * @abstract
    * @param {Array<string>|string} topics
-   * @param {any} message
-   * @returns {Promise}
+   * @param {Buffer | string} message
+   * @returns {Promise<void>}
    *
    */
   publish (topics, message) {

--- a/src/index.js
+++ b/src/index.js
@@ -314,11 +314,11 @@ class PubsubBaseProtocol extends EventEmitter {
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
    * @abstract
    * @param {Array<string>|string} topics
-   * @param {Array<any>|any} messages
+   * @param {any} message
    * @returns {Promise}
    *
    */
-  publish (topics, messages) {
+  publish (topics, message) {
     throw errcode(new Error('publish must be implemented by the subclass'), 'ERR_NOT_IMPLEMENTED')
   }
 


### PR DESCRIPTION
Resolves https://github.com/libp2p/js-libp2p-pubsub/issues/51

BREAKING CHANGE: the publish function signature now takes a single
message as its second parameter, instead of optionally an array of
messages.