### PR TITLE
chore: fix verifySignature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ class PubsubBaseProtocol extends EventEmitter {
     }
 
     // Check the message signature if present
-    if (message.signature && !verifySignature(message)) {
+    if (message.signature && !(await verifySignature(message))) {
       throw errcode(new Error('Invalid message signature'), codes.ERR_INVALID_SIGNATURE)
     }
   }

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -29,7 +29,7 @@ async function signMessage (peerId, message) {
 
 /**
  * Verifies the signature of the given message
- * @param {rpc.RPC.Message} message
+ * @param {InMessage} message
  * @returns {Promise<Boolean>}
  */
 async function verifySignature (message) {
@@ -37,6 +37,9 @@ async function verifySignature (message) {
   const baseMessage = { ...message }
   delete baseMessage.signature
   delete baseMessage.key
+  if (typeof baseMessage.from === 'string') {
+    baseMessage.from = PeerId.createFromB58String(baseMessage.from).toBytes()
+  }
   const bytes = Buffer.concat([
     SignPrefix,
     Message.encode(baseMessage)
@@ -46,7 +49,7 @@ async function verifySignature (message) {
   const pubKey = await messagePublicKey(message)
 
   // verify the base message
-  return pubKey.verify(bytes, message.signature)
+  return await pubKey.verify(bytes, message.signature)
 }
 
 /**

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -49,7 +49,7 @@ async function verifySignature (message) {
   const pubKey = await messagePublicKey(message)
 
   // verify the base message
-  return await pubKey.verify(bytes, message.signature)
+  return pubKey.verify(bytes, message.signature)
 }
 
 /**


### PR DESCRIPTION
Fix verifySignature function to take an `InMessage` object (in a 'backwards compatible' way)
Fix verifySignature usage (was not awaiting the result!)