### PR TITLE
fix: fix issue introduced with 0.4.7 changes used with ipfs 0.46.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ docs
 
 package-lock.json
 yarn.lock
+
+.idea

--- a/src/peer.js
+++ b/src/peer.js
@@ -100,11 +100,17 @@ class Peer extends EventEmitter {
     })
     this.conn = conn
 
-    pipe(
+    const piped = pipe(
       this.stream,
       lp.encode(),
       conn
-    ).catch(err => {
+    )
+
+    if (piped == null) {
+      return
+    }
+
+    piped.catch(err => {
       log.error(err)
     })
 


### PR DESCRIPTION
We've noticed the issue introduced in `0.4.7` when using in the combination with ipfs `0.46.0`.

Piped functions are returning null and `catch` is causing the problem.