### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-pubsub#readme",
   "devDependencies": {
-    "aegir": "^22.0.0",
+    "aegir": "^25.0.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "chai-spies": "^1.0.0",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
-    "multiaddr": "^7.2.1",
+    "multiaddr": "^8.0.0",
     "sinon": "^9.0.0"
   },
   "dependencies": {
@@ -57,11 +57,12 @@
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
     "it-pushable": "^1.3.2",
-    "libp2p-crypto": "~0.17.0",
-    "libp2p-interfaces": "^0.3.0",
-    "multibase": "^0.7.0",
-    "peer-id": "~0.13.3",
-    "protons": "^1.0.1"
+    "libp2p-crypto": "^0.18.0",
+    "libp2p-interfaces": "^0.4.0",
+    "multibase": "^3.0.0",
+    "peer-id": "^0.14.0",
+    "protons": "^2.0.0",
+    "uint8arrays": "^1.1.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",

--- a/src/message/sign.js
+++ b/src/message/sign.js
@@ -1,8 +1,10 @@
 'use strict'
-const { Buffer } = require('buffer')
+
 const PeerId = require('peer-id')
 const { Message } = require('./index')
-const SignPrefix = Buffer.from('libp2p-pubsub:')
+const uint8ArrayConcat = require('uint8arrays/concat')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const SignPrefix = uint8ArrayFromString('libp2p-pubsub:')
 
 /**
  * Signs the provided message with the given `peerId`
@@ -13,7 +15,7 @@ const SignPrefix = Buffer.from('libp2p-pubsub:')
  */
 async function signMessage (peerId, message) {
   // Get the message in bytes, and prepend with the pubsub prefix
-  const bytes = Buffer.concat([
+  const bytes = uint8ArrayConcat([
     SignPrefix,
     Message.encode(message)
   ])
@@ -37,7 +39,7 @@ async function verifySignature (message) {
   const baseMessage = { ...message }
   delete baseMessage.signature
   delete baseMessage.key
-  const bytes = Buffer.concat([
+  const bytes = uint8ArrayConcat([
     SignPrefix,
     Message.encode(baseMessage)
   ])

--- a/src/peer.js
+++ b/src/peer.js
@@ -67,7 +67,7 @@ class Peer extends EventEmitter {
    * Send a message to this peer.
    * Throws if there is no `stream` to write to available.
    *
-   * @param {Buffer} msg
+   * @param {Uint8Array} msg
    * @returns {undefined}
    */
   write (msg) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,16 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const crypto = require('libp2p-crypto')
 const multibase = require('multibase')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 exports = module.exports
 
 /**
  * Generatea random sequence number.
  *
- * @returns {Buffer}
+ * @returns {Uint8Array}
  * @private
  */
 exports.randomSeqno = () => {
@@ -20,12 +21,12 @@ exports.randomSeqno = () => {
  * Generate a message id, based on the `from` and `seqno`.
  *
  * @param {string} from
- * @param {Buffer} seqno
+ * @param {Uint8Array} seqno
  * @returns {string}
  * @private
  */
 exports.msgId = (from, seqno) => {
-  return from + seqno.toString('hex')
+  return from + uint8ArrayToString(seqno, 'base16')
 }
 
 /**
@@ -72,13 +73,13 @@ exports.ensureArray = (maybeArray) => {
 /**
  * Ensures `message.from` is base58 encoded
  * @param {Object} message
- * @param {Buffer|String} message.from
+ * @param {Uint8Array|String} message.from
  * @return {Object}
  */
 exports.normalizeInRpcMessage = (message) => {
   const m = Object.assign({}, message)
-  if (Buffer.isBuffer(message.from)) {
-    m.from = multibase.encode('base58btc', message.from).toString().slice(1)
+  if (message.from instanceof Uint8Array) {
+    m.from = uint8ArrayToString(message.from, 'base58btc')
   }
   return m
 }
@@ -99,6 +100,9 @@ exports.normalizeOutRpcMessage = (message) => {
   const m = Object.assign({}, message)
   if (typeof message.from === 'string' || message.from instanceof String) {
     m.from = multibase.decode('z' + message.from)
+  }
+  if (typeof message.data === 'string' || message.data instanceof String) {
+    m.data = uint8ArrayFromString(message.data)
   }
   return m
 }

--- a/test/sign.spec.js
+++ b/test/sign.spec.js
@@ -2,10 +2,11 @@
 /* eslint max-nested-callbacks: ["error", 5] */
 'use strict'
 
-const { Buffer } = require('buffer')
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
+const uint8ArrayConcat = require('uint8arrays/concat')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const { Message } = require('../src/message')
 const {
@@ -27,12 +28,12 @@ describe('message signing', () => {
   it('should be able to sign and verify a message', async () => {
     const message = {
       from: peerId.id,
-      data: 'hello',
+      data: uint8ArrayFromString('hello'),
       seqno: randomSeqno(),
       topicIDs: ['test-topic']
     }
 
-    const bytesToSign = Buffer.concat([SignPrefix, Message.encode(message)])
+    const bytesToSign = uint8ArrayConcat([SignPrefix, Message.encode(message)])
     const expectedSignature = await peerId.privKey.sign(bytesToSign)
 
     const signedMessage = await signMessage(peerId, message)
@@ -51,12 +52,12 @@ describe('message signing', () => {
 
     const message = {
       from: secPeerId.id,
-      data: 'hello',
+      data: uint8ArrayFromString('hello'),
       seqno: randomSeqno(),
       topicIDs: ['test-topic']
     }
 
-    const bytesToSign = Buffer.concat([SignPrefix, Message.encode(message)])
+    const bytesToSign = uint8ArrayConcat([SignPrefix, Message.encode(message)])
     const expectedSignature = await secPeerId.privKey.sign(bytesToSign)
 
     const signedMessage = await signMessage(secPeerId, message)
@@ -73,12 +74,12 @@ describe('message signing', () => {
   it('should be able to extract the public key from the message', async () => {
     const message = {
       from: peerId.id,
-      data: 'hello',
+      data: uint8ArrayFromString('hello'),
       seqno: randomSeqno(),
       topicIDs: ['test-topic']
     }
 
-    const bytesToSign = Buffer.concat([SignPrefix, Message.encode(message)])
+    const bytesToSign = uint8ArrayConcat([SignPrefix, Message.encode(message)])
     const expectedSignature = await peerId.privKey.sign(bytesToSign)
 
     const signedMessage = await signMessage(peerId, message)

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -2,8 +2,8 @@
 'use strict'
 
 const { expect } = require('chai')
-const { Buffer } = require('buffer')
 const utils = require('../src/utils')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('utils', () => {
   it('randomSeqno', () => {
@@ -16,13 +16,13 @@ describe('utils', () => {
   })
 
   it('msgId', () => {
-    expect(utils.msgId('hello', Buffer.from('world'))).to.be.eql('hello776f726c64')
+    expect(utils.msgId('hello', uint8ArrayFromString('world'))).to.be.eql('hello776f726c64')
   })
 
-  it('msgId should not generate same ID for two different buffers', () => {
+  it('msgId should not generate same ID for two different Uint8Arrays', () => {
     const peerId = 'QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22'
-    const msgId0 = utils.msgId(peerId, Buffer.from('15603533e990dfde', 'hex'))
-    const msgId1 = utils.msgId(peerId, Buffer.from('15603533e990dfe0', 'hex'))
+    const msgId0 = utils.msgId(peerId, uint8ArrayFromString('15603533e990dfde', 'base16'))
+    const msgId1 = utils.msgId(peerId, uint8ArrayFromString('15603533e990dfe0', 'base16'))
     expect(msgId0).to.not.eql(msgId1)
   })
 
@@ -49,7 +49,7 @@ describe('utils', () => {
   })
 
   it('converts an IN msg.from to b58', () => {
-    const binaryId = Buffer.from('1220e2187eb3e6c4fb3e7ff9ad4658610624a6315e0240fc6f37130eedb661e939cc', 'hex')
+    const binaryId = uint8ArrayFromString('1220e2187eb3e6c4fb3e7ff9ad4658610624a6315e0240fc6f37130eedb661e939cc', 'base16')
     const stringId = 'QmdZEWgtaWAxBh93fELFT298La1rsZfhiC2pqwMVwy3jZM'
     const m = [
       { from: binaryId },
@@ -63,7 +63,7 @@ describe('utils', () => {
   })
 
   it('converts an OUT msg.from to binary', () => {
-    const binaryId = Buffer.from('1220e2187eb3e6c4fb3e7ff9ad4658610624a6315e0240fc6f37130eedb661e939cc', 'hex')
+    const binaryId = uint8ArrayFromString('1220e2187eb3e6c4fb3e7ff9ad4658610624a6315e0240fc6f37130eedb661e939cc', 'base16')
     const stringId = 'QmdZEWgtaWAxBh93fELFT298La1rsZfhiC2pqwMVwy3jZM'
     const m = [
       { from: binaryId },


### PR DESCRIPTION
All uses of node Buffers have been replaced with Uint8Arrays

BREAKING CHANGES:

- The `.data` and `.seq` properties of messages used to be node Buffers, now they are Uint8Arrays
- All deps of this module now use Uint8Arrays instead of Buffers