### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ⛔️ DEPRECATED
+
+libp2p-pubsub was refactored and is now in [libp2p/js-libp2p-interfaces/src/pubsub](https://github.com/libp2p/js-libp2p-interfaces/tree/master/src/pubsub). If you want to create a libp2p compatible pubsub router you should use the interface from `libp2p@0.29`.
+
+_This library will not be maintained._
+
 js-libp2p-pubsub
 ==================
 


### PR DESCRIPTION
With `libp2p@0.29`, we should deprecate it and archive the repo in the next libp2p release