### PR TITLE
wip: pubsub's multicodecs changed to a `Set`

### DIFF
--- a/test/emit-self.spec.ts
+++ b/test/emit-self.spec.ts
@@ -21,7 +21,7 @@ describe('emitSelf', () => {
       const peerId = await createPeerId()
 
       pubsub = new PubsubImplementation({
-        multicodecs: [protocol],
+        multicodecs: new Set([protocol]),
         emitSelf: true
       })
       pubsub.init(new Components({
@@ -77,7 +77,7 @@ describe('emitSelf', () => {
       const peerId = await createPeerId()
 
       pubsub = new PubsubImplementation({
-        multicodecs: [protocol],
+        multicodecs: new Set([protocol]),
         emitSelf: false
       })
       pubsub.init(new Components({

--- a/test/instance.spec.ts
+++ b/test/instance.spec.ts
@@ -35,7 +35,7 @@ describe('pubsub instance', () => {
   it('should accept valid parameters', () => {
     expect(() => {
       new PubsubProtocol({ // eslint-disable-line no-new
-        multicodecs: ['/pubsub/1.0.0']
+        multicodecs: new Set(['/pubsub/1.0.0'])
       })
     }).not.to.throw()
   })

--- a/test/lifecycle.spec.ts
+++ b/test/lifecycle.spec.ts
@@ -51,7 +51,7 @@ describe('pubsub base lifecycle', () => {
       }
 
       pubsub = new PubsubProtocol({
-        multicodecs: ['/pubsub/1.0.0']
+        multicodecs: new Set(['/pubsub/1.0.0'])
       })
       pubsub.init(new Components({
         peerId: peerId,
@@ -111,14 +111,14 @@ describe('pubsub base lifecycle', () => {
       registrarB = new MockRegistrar()
 
       pubsubA = new PubsubImplementation({
-        multicodecs: [protocol]
+        multicodecs: new Set([protocol])
       })
       pubsubA.init(new Components({
         peerId: peerIdA,
         registrar: registrarA
       }))
       pubsubB = new PubsubImplementation({
-        multicodecs: [protocol]
+        multicodecs: new Set([protocol])
       })
       pubsubB.init(new Components({
         peerId: peerIdB,

--- a/test/message.spec.ts
+++ b/test/message.spec.ts
@@ -18,7 +18,7 @@ describe('pubsub base messages', () => {
   before(async () => {
     peerId = await createPeerId()
     pubsub = new PubsubImplementation({
-      multicodecs: ['/pubsub/1.0.0']
+      multicodecs: new Set(['/pubsub/1.0.0'])
     })
     pubsub.init(new Components({
       peerId: peerId,

--- a/test/pubsub.spec.ts
+++ b/test/pubsub.spec.ts
@@ -31,7 +31,7 @@ describe('pubsub base implementation', () => {
     beforeEach(async () => {
       const peerId = await createPeerId()
       pubsub = new PubsubImplementation({
-        multicodecs: [protocol],
+        multicodecs: new Set([protocol]),
         emitSelf: true
       })
       pubsub.init(new Components({
@@ -107,7 +107,7 @@ describe('pubsub base implementation', () => {
       beforeEach(async () => {
         const peerId = await createPeerId()
         pubsub = new PubsubImplementation({
-          multicodecs: [protocol]
+          multicodecs: new Set([protocol])
         })
         pubsub.init(new Components({
           peerId: peerId,
@@ -140,14 +140,14 @@ describe('pubsub base implementation', () => {
         registrarB = new MockRegistrar()
 
         pubsubA = new PubsubImplementation({
-          multicodecs: [protocol]
+          multicodecs: new Set([protocol])
         })
         pubsubA.init(new Components({
           peerId: peerIdA,
           registrar: registrarA
         }))
         pubsubB = new PubsubImplementation({
-          multicodecs: [protocol]
+          multicodecs: new Set([protocol])
         })
         pubsubB.init(new Components({
           peerId: peerIdB,
@@ -212,7 +212,7 @@ describe('pubsub base implementation', () => {
       beforeEach(async () => {
         const peerId = await createPeerId()
         pubsub = new PubsubImplementation({
-          multicodecs: [protocol]
+          multicodecs: new Set([protocol])
         })
         pubsub.init(new Components({
           peerId: peerId,
@@ -249,14 +249,14 @@ describe('pubsub base implementation', () => {
         registrarB = new MockRegistrar()
 
         pubsubA = new PubsubImplementation({
-          multicodecs: [protocol]
+          multicodecs: new Set([protocol])
         })
         pubsubA.init(new Components({
           peerId: peerIdA,
           registrar: registrarA
         }))
         pubsubB = new PubsubImplementation({
-          multicodecs: [protocol]
+          multicodecs: new Set([protocol])
         })
         pubsubB.init(new Components({
           peerId: peerIdB,
@@ -345,7 +345,7 @@ describe('pubsub base implementation', () => {
     beforeEach(async () => {
       peerId = await createPeerId()
       pubsub = new PubsubImplementation({
-        multicodecs: [protocol]
+        multicodecs: new Set([protocol])
       })
       pubsub.init(new Components({
         peerId: peerId,
@@ -375,7 +375,7 @@ describe('pubsub base implementation', () => {
     beforeEach(async () => {
       peerId = await createPeerId()
       pubsub = new PubsubImplementation({
-        multicodecs: [protocol]
+        multicodecs: new Set([protocol])
       })
       pubsub.init(new Components({
         peerId: peerId,
@@ -447,7 +447,7 @@ describe('pubsub base implementation', () => {
     beforeEach(async () => {
       peerId = await createPeerId()
       pubsub = new PubsubImplementation({
-        multicodecs: [protocol]
+        multicodecs: new Set([protocol])
       })
       pubsub.init(new Components({
         peerId: peerId,

--- a/test/topic-validators.spec.ts
+++ b/test/topic-validators.spec.ts
@@ -26,7 +26,7 @@ describe('topic validators', () => {
     otherPeerId = await createEd25519PeerId()
 
     pubsub = new PubsubImplementation({
-      multicodecs: [protocol],
+      multicodecs: new Set([protocol]),
       globalSignaturePolicy: 'StrictNoSign'
     })
     pubsub.init(new Components({


### PR DESCRIPTION
Related to https://github.com/libp2p/js-libp2p-interfaces/pull/260

I had to do the changes to run libp2p-gossipsub's benchmark.

Parking them until decision made for the libp2p-interfaces change