### PR TITLE
feat: remove unnecessary direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "@multiformats/multiaddr": "^10.2.0",
     "abortable-iterator": "^4.0.2",
     "err-code": "^3.0.1",
-    "iso-random-stream": "^2.0.0",
     "it-length-prefixed": "^8.0.2",
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.0.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'iso-random-stream'
+import { randomBytes } from '@libp2p/crypto'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { sha256 } from 'multiformats/hashes/sha2'


### PR DESCRIPTION
Remove `iso-random-stream` direct dependency, use `randomBytes` API from
`@libp2p/crypto` instead.

`iso-random-stream` brings in `buffer` dependency which then needs to be
polyfilled when targeting the browser.