### PR TITLE
fix: allow `key` field to be unset

### DIFF
--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -3,6 +3,7 @@ import * as utils from '../src/utils.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import type { Message, PubSubRPCMessage } from '@libp2p/interface-pubsub'
 import { peerIdFromBytes, peerIdFromString } from '@libp2p/peer-id'
+import * as PeerIdFactory from '@libp2p/peer-id-factory'
 
 describe('utils', () => {
   it('randomSeqno', () => {
@@ -93,5 +94,38 @@ describe('utils', () => {
     values.forEach(val => {
       expect(utils.bigIntFromBytes(utils.bigIntToBytes(val))).to.equal(val)
     })
+  })
+
+  it('ensures message is signed if public key is extractable', async () => {
+    const cases: PubSubRPCMessage[] = [
+      {
+        from: (await PeerIdFactory.createSecp256k1PeerId()).toBytes(),
+        topic: 'test',
+        data: new Uint8Array(0),
+        sequenceNumber: utils.bigIntToBytes(1n),
+        signature: new Uint8Array(0)
+      },
+      {
+        from: peerIdFromString('QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22').toBytes(),
+        topic: 'test',
+        data: new Uint8Array(0),
+        sequenceNumber: utils.bigIntToBytes(1n),
+        signature: new Uint8Array(0)
+      },
+      {
+        from: peerIdFromString('QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22').toBytes(),
+        topic: 'test',
+        data: new Uint8Array(0),
+        sequenceNumber: utils.bigIntToBytes(1n),
+        signature: new Uint8Array(0),
+        // dummy value which will fail verification
+        key: new Uint8Array(0)
+      }
+    ]
+    const expected = ['signed', 'unsigned', 'signed']
+
+    const actual = cases.map(utils.toMessage).map(m => m.type)
+
+    expect(actual).to.deep.equal(expected)
   })
 })

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -97,6 +97,8 @@ describe('utils', () => {
   })
 
   it('ensures message is signed if public key is extractable', async () => {
+    const dummyPeerID = await PeerIdFactory.createRSAPeerId()
+
     const cases: PubSubRPCMessage[] = [
       {
         from: (await PeerIdFactory.createSecp256k1PeerId()).toBytes(),
@@ -113,18 +115,17 @@ describe('utils', () => {
         signature: new Uint8Array(0)
       },
       {
-        from: peerIdFromString('QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22').toBytes(),
+        from: dummyPeerID.toBytes(),
         topic: 'test',
         data: new Uint8Array(0),
         sequenceNumber: utils.bigIntToBytes(1n),
         signature: new Uint8Array(0),
-        // dummy value which will fail verification
-        key: new Uint8Array(0)
+        key: dummyPeerID.publicKey
       }
     ]
     const expected = ['signed', 'unsigned', 'signed']
 
-    const actual = cases.map(utils.toMessage).map(m => m.type)
+    const actual = (await Promise.all(cases.map(utils.toMessage))).map(m => m.type)
 
     expect(actual).to.deep.equal(expected)
   })


### PR DESCRIPTION
Allows field key to not be set in case key can be extracted from the sender's peer ID. (as per https://github.com/libp2p/specs/tree/master/pubsub#message-signing)