### PR TITLE
fix: get key from peer id if not specified in the message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,16 +97,23 @@ export const toMessage = async (message: PubSubRPCMessage): Promise<Message> => 
     }
   }
 
-  return {
+  const from = peerIdFromBytes(message.from)
+
+  const msg: Message = {
     type: 'signed',
     from: peerIdFromBytes(message.from),
     topic: message.topic ?? '',
     sequenceNumber: bigIntFromBytes(message.sequenceNumber ?? new Uint8Array(0)),
     data: message.data ?? new Uint8Array(0),
     signature: message.signature ?? new Uint8Array(0),
-    // @ts-expect-error key need not be defined
-    key: message.key
+    key: message.key ?? from.publicKey ?? new Uint8Array(0)
   }
+
+  if (msg.key.length === 0) {
+    throw new CodeError('Signed RPC message was missing key', codes.ERR_MISSING_KEY)
+  }
+
+  return msg
 }
 
 export const toRpcMessage = (message: Message): PubSubRPCMessage => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -121,10 +121,17 @@ describe('utils', () => {
         sequenceNumber: utils.bigIntToBytes(1n),
         signature: new Uint8Array(0),
         key: dummyPeerID.publicKey
+      },
+      {
+        from: (await PeerIdFactory.createEd25519PeerId()).toBytes(),
+        topic: 'test',
+        data: new Uint8Array(0),
+        sequenceNumber: utils.bigIntToBytes(1n),
+        signature: new Uint8Array(0)
       }
     ]
-    const expected = ['signed', 'unsigned', 'signed']
 
+    const expected = ['signed', 'unsigned', 'signed', 'signed']
     const actual = (await Promise.all(cases.map(utils.toMessage))).map(m => m.type)
 
     expect(actual).to.deep.equal(expected)


### PR DESCRIPTION
Remove the `@ts-expect-error` and use the public key of the peer id if it's not specified in the message.